### PR TITLE
Bugfix on #4 : Missing time support on datetime

### DIFF
--- a/VacantRoomFinder.py
+++ b/VacantRoomFinder.py
@@ -128,8 +128,8 @@ class FreeRoomFinder(commands.Cog):
 
 
     @commands.command(name='findroom')
-    async def find_room(self, ctx, moment = None):
-        
+    async def find_room(self, ctx, *moments):
+        moment = " ".join(moments) # Pour accepter les formats en deux parties (ex 10/04 11h40)
         # TODO: ajouter slash_commands avec choix pour les batiments ? solution pour le @moment ?
 
         if not moment:


### PR DESCRIPTION
Bugfix on #4 - Missing time support on datetime.

Switching moment argument from a variable to a list, so it can accept multiple " " divided by arguments in input.